### PR TITLE
Dockerize Laravel application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Use php:7.4-fpm as the base image
+FROM php:7.4-fpm
+
+# Install necessary PHP extensions and dependencies
+RUN apt-get update && apt-get install -y libonig-dev
+RUN docker-php-ext-install pdo pdo_mysql mbstring
+
+# Set the working directory
+WORKDIR /var/www
+
+# Copy the application code into the Docker image
+COPY . .
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install PHP dependencies
+RUN composer install
+
+# Copy the .env.example file to .env
+RUN cp .env.example .env
+
+# Generate an application key
+RUN php artisan key:generate
+
+# Set the appropriate permissions
+RUN chown -R www-data:www-data storage bootstrap/cache
+RUN chmod -R 775 storage bootstrap/cache
+
+# Expose port 80
+EXPOSE 80
+
+# Define the command to run the Laravel application
+CMD ["php", "artisan", "serve", "--host=0.0.0.0", "--port=80"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: lab-reporting-system-app
+    env_file:
+      - .env
+    volumes:
+      - .:/var/www
+    networks:
+      - lab-reporting-system-network
+
+  web:
+    image: nginx:alpine
+    container_name: lab-reporting-system-web
+    volumes:
+      - .:/var/www
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+    depends_on:
+      - app
+    networks:
+      - lab-reporting-system-network
+
+  db:
+    image: mysql:5.7
+    container_name: lab-reporting-system-db
+    env_file:
+      - .env
+    volumes:
+      - db_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    networks:
+      - lab-reporting-system-network
+
+volumes:
+  db_data:
+
+networks:
+  lab-reporting-system-network:
+    driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,53 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        root /var/www/public;
+        index index.php index.html index.htm;
+
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+            try_files $uri =404;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass app:9000;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
+
+        location ~ /\.ht {
+            deny  all;
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -62,3 +62,31 @@ This was my final year project at AUST. Built with Laravel 5.3.
 ![Imgur](https://i.imgur.com/4mQ0HMn.png)
 
 ![Imgur](https://i.imgur.com/GQAcgve.png)
+
+## Running the application in a Docker container
+
+1. Ensure you have Docker and Docker Compose installed on your machine.
+1. Clone the repository and navigate to the project root directory.
+1. Copy the `.env.example` file to `.env` and update the necessary environment variables.
+1. Build and start the Docker containers using Docker Compose:
+    ```
+    docker-compose up --build
+    ```
+1. Once the containers are up and running, you can access the application at `http://localhost`.
+1. Run the database migrations and seeders:
+    ```
+    docker-compose exec app php artisan migrate --seed
+    ```
+1. You can now log in with the following credentials:
+
+    *Email:* admin@email.com
+
+    *Pass:* 12345
+
+    There is also another user of role `Laboratorist`.
+
+    *Email:* lab@email.com
+
+    *Pass:* 12345
+
+1. Front page is at route `front/index`


### PR DESCRIPTION
Add Dockerfile to set up Laravel 5.3 application in a Docker container.

* Use `php:7.4-fpm` as the base image.
* Install necessary PHP extensions and dependencies, including `libonig-dev` to resolve the oniguruma dependency issue.
* Set the working directory to `/var/www`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jp-pelegrino/lab-reporting-system?shareId=3da9f958-198b-40ab-b1e2-b776ff55744b).