### PR TITLE
Fix Docker Compose configuration for web and app services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - .:/var/www
     networks:
       - lab-reporting-system-network
+    command: >
+      sh -c "composer install && php artisan key:generate && php artisan migrate --seed && php artisan serve --host=0.0.0.0 --port=80"
 
   web:
     image: nginx:alpine


### PR DESCRIPTION
Update `docker-compose.yml` to ensure services run correctly.

* Add a command to the `app` service to run `composer install`, `php artisan key:generate`, `php artisan migrate --seed`, and `php artisan serve` during container startup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jp-pelegrino/lab-reporting-system?shareId=486a212c-fbc7-457b-aa97-e9615f498c47).